### PR TITLE
Fix `BoardCell` (old versions, typing)

### DIFF
--- a/src/BoardPhysics.ts
+++ b/src/BoardPhysics.ts
@@ -1,4 +1,4 @@
-import { BoardCell } from "./components/BoardCell";
+import { BoardCell } from "./BoardCell";
 import { _ENABLE_UP_KEY, EMPTY } from "./setup";
 
 export class BoardPhysics {

--- a/src/components/BoardCell.tsx
+++ b/src/components/BoardCell.tsx
@@ -1,17 +1,18 @@
 import styled from "styled-components";
+import { BoardCell } from "../BoardCell";
 import { EMPTY } from "../setup";
 
 export const BoardCellStyled = styled.div`
   width: auto;
-  background: ${(props) => {
-    if (props.char === EMPTY) {
-        return "none";
-    } else if (props.hasMatched) {
-        return "lightgreen;";
-    } else {
-        return "red";
-    }
-}};
+  background: ${(props: BoardCell) => {
+        if (props.char === EMPTY) {
+            return "none";
+        } else if (props.hasMatched) {
+            return "lightgreen;";
+        } else {
+            return "red";
+        }
+    }};
   text: ${(props) => props.char === EMPTY ? "none" : "red"};
   border: 2px solid;
   grid-row: ${(props) => props.r};

--- a/src/components/BoardCell.tsx
+++ b/src/components/BoardCell.tsx
@@ -1,11 +1,6 @@
 import styled from "styled-components";
 import { EMPTY } from "../setup";
 
-export interface BoardCell {
-    x: number;
-    y: number;
-}
-
 export const BoardCellStyled = styled.div`
   width: auto;
   background: ${(props) => {

--- a/src/components/BoardCell.tsx
+++ b/src/components/BoardCell.tsx
@@ -5,14 +5,14 @@ import { EMPTY } from "../setup";
 export const BoardCellStyled = styled.div`
   width: auto;
   background: ${(props: BoardCell) => {
-        if (props.char === EMPTY) {
-            return "none";
-        } else if (props.hasMatched) {
-            return "lightgreen;";
-        } else {
-            return "red";
-        }
-    }};
+    if (props.char === EMPTY) {
+        return "none";
+    } else if (props.hasMatched) {
+        return "lightgreen;";
+    } else {
+        return "red";
+    }
+}};
   text: ${(props) => props.char === EMPTY ? "none" : "red"};
   border: 2px solid;
   grid-row: ${(props) => props.r};


### PR DESCRIPTION
* Delete the old `BoardCell` (there were two versions and one had fewer fields that caused type errors).
* Switch imports to the new `BoardCell` to fix a bunch of type errors.
* Add more `: BoardCell` type annotations to fix more type errors.