### PR TITLE
Disable player block visibility & movement during word-matching animation

### DIFF
--- a/src/GameLoop.tsx
+++ b/src/GameLoop.tsx
@@ -71,7 +71,6 @@ let matchAnimStart = null;
 const matchAnimLength = 750;
 let isMatchChaining = false;
 
-
 let didInstantDrop = false;
 
 function updatePlayerPos(
@@ -235,12 +234,13 @@ globalThis.addEventListener(
     false,
 ); // Without bind it loses context.
 
+const gameState = {
+    setPlayerCells: null,
+    setPlayerVisible: null,
+    setBoardCells: null,
+};
+
 export function GameLoop() {
-    const gameState = {
-        setPlayerCells: null,
-        setBoardCells: null,
-        isPlayerVisible: true,
-    };
 
     const res = (
         <BoardStyled>
@@ -289,12 +289,8 @@ export function GameLoop() {
         }
 
         // Update rendering.
-        if (gameState.setPlayerCells != null) {
             gameState.setPlayerCells(playerPhysics.adjustedCells);
-        }
-        if (gameState.setBoardCells != null) {
             gameState.setBoardCells(boardPhysics.boardCellMatrix);
-        }
         globalThis.requestAnimationFrame(loop);
     }
 
@@ -365,7 +361,8 @@ export function GameLoop() {
     function handleStates() {
         // console.log(stateHandler.state.value)
         if ("spawningBlock" == stateHandler.state.value) {
-            gameState.isPlayerVisible = true;
+            console.log('spawning')
+            gameState.setPlayerVisible(true);
             placedCells.clear();
             stateHandler.send("SPAWN");
             console.log("event: spawningBlock ~ SPAWN");
@@ -398,7 +395,7 @@ export function GameLoop() {
                 didInstantDrop = false;
 
                 stateHandler.send("LOCK");
-                gameState.isPlayerVisible = false;
+                gameState.setPlayerVisible(false);
                 console.log("event: lockDelay ~ SEND");
             }
         } else if ("fallingLetters" == stateHandler.state.value) {
@@ -530,7 +527,6 @@ export function GameLoop() {
                     console.log("event: playMatchAnimation ~ DO_CHAIN");
                 }
             } else {
-                console.log('hi')
                 stateHandler.send("DONE");
                 console.log("event: playMatchAnimation ~ DONE");
             }

--- a/src/GameLoop.tsx
+++ b/src/GameLoop.tsx
@@ -70,6 +70,7 @@ const lockMax = 1500;
 let matchAnimStart = null;
 const matchAnimLength = 750;
 let isMatchChaining = false;
+let isPlayerMovementEnabled = false;
 
 let didInstantDrop = false;
 
@@ -78,6 +79,9 @@ function updatePlayerPos(
     boardPhysics: BoardPhysics,
     { keyCode, repeat }: { keyCode: number; repeat: boolean },
 ): void {
+    if (!isPlayerMovementEnabled) {
+        return;
+    }
     const board = boardPhysics.boardCellMatrix;
     const r = playerPhysics.pos[0];
     const c = playerPhysics.pos[1];
@@ -270,13 +274,15 @@ export function GameLoop() {
         while (accum >= frameStep) {
             accum -= frameStep;
             handleStates();
-            const dr = playerPhysics.doGradualFall(
-                boardPhysics.boardCellMatrix,
-            );
-            playerPhysics.setPos(
-                playerPhysics.pos[0] + dr,
-                playerPhysics.pos[1],
-            );
+            if (isPlayerMovementEnabled) {
+                const dr = playerPhysics.doGradualFall(
+                    boardPhysics.boardCellMatrix,
+                );
+                playerPhysics.setPos(
+                    playerPhysics.pos[0] + dr,
+                    playerPhysics.pos[1],
+                );
+            }
             // Reset if spawn point is blocked.
             if (
                 boardPhysics
@@ -289,8 +295,8 @@ export function GameLoop() {
         }
 
         // Update rendering.
-            gameState.setPlayerCells(playerPhysics.adjustedCells);
-            gameState.setBoardCells(boardPhysics.boardCellMatrix);
+        gameState.setPlayerCells(playerPhysics.adjustedCells);
+        gameState.setBoardCells(boardPhysics.boardCellMatrix);
         globalThis.requestAnimationFrame(loop);
     }
 
@@ -361,7 +367,7 @@ export function GameLoop() {
     function handleStates() {
         // console.log(stateHandler.state.value)
         if ("spawningBlock" == stateHandler.state.value) {
-            console.log('spawning')
+            isPlayerMovementEnabled = true;
             gameState.setPlayerVisible(true);
             placedCells.clear();
             stateHandler.send("SPAWN");
@@ -395,6 +401,8 @@ export function GameLoop() {
                 didInstantDrop = false;
 
                 stateHandler.send("LOCK");
+                // Disable player block features.
+                isPlayerMovementEnabled = false;
                 gameState.setPlayerVisible(false);
                 console.log("event: lockDelay ~ SEND");
             }

--- a/src/GameLoop.tsx
+++ b/src/GameLoop.tsx
@@ -71,6 +71,7 @@ let matchAnimStart = null;
 const matchAnimLength = 750;
 let isMatchChaining = false;
 
+
 let didInstantDrop = false;
 
 function updatePlayerPos(
@@ -95,7 +96,7 @@ function updatePlayerPos(
             (!ENABLE_SMOOTH_FALL ||
                 playerPhysics.isInRBounds(
                     playerPhysics.getAdjustedBottomR() +
-                        Math.ceil(interp.val / interpMax),
+                    Math.ceil(interp.val / interpMax),
                 )) &&
             areTargetSpacesEmpty(
                 Math.ceil(ENABLE_SMOOTH_FALL ? interp.val / interpMax : 0),
@@ -115,7 +116,7 @@ function updatePlayerPos(
             (!ENABLE_SMOOTH_FALL ||
                 playerPhysics.isInRBounds(
                     playerPhysics.getAdjustedBottomR() +
-                        Math.ceil(interp.val / interpMax),
+                    Math.ceil(interp.val / interpMax),
                 )) &&
             areTargetSpacesEmpty(
                 Math.ceil(ENABLE_SMOOTH_FALL ? interp.val / interpMax : 0),
@@ -238,6 +239,7 @@ export function GameLoop() {
     const gameState = {
         setPlayerCells: null,
         setBoardCells: null,
+        isPlayerVisible: true,
     };
 
     const res = (
@@ -279,8 +281,8 @@ export function GameLoop() {
             if (
                 boardPhysics
                     .boardCellMatrix[playerPhysics.spawnPos[0]][
-                        playerPhysics.spawnPos[1]
-                    ].char !== EMPTY
+                    playerPhysics.spawnPos[1]
+                ].char !== EMPTY
             ) {
                 boardPhysics.resetBoard(BOARD_ROWS, BOARD_COLS);
             }
@@ -363,6 +365,7 @@ export function GameLoop() {
     function handleStates() {
         // console.log(stateHandler.state.value)
         if ("spawningBlock" == stateHandler.state.value) {
+            gameState.isPlayerVisible = true;
             placedCells.clear();
             stateHandler.send("SPAWN");
             console.log("event: spawningBlock ~ SPAWN");
@@ -395,6 +398,7 @@ export function GameLoop() {
                 didInstantDrop = false;
 
                 stateHandler.send("LOCK");
+                gameState.isPlayerVisible = false;
                 console.log("event: lockDelay ~ SEND");
             }
         } else if ("fallingLetters" == stateHandler.state.value) {
@@ -526,6 +530,7 @@ export function GameLoop() {
                     console.log("event: playMatchAnimation ~ DO_CHAIN");
                 }
             } else {
+                console.log('hi')
                 stateHandler.send("DONE");
                 console.log("event: playMatchAnimation ~ DONE");
             }

--- a/src/GameLoop.tsx
+++ b/src/GameLoop.tsx
@@ -99,7 +99,7 @@ function updatePlayerPos(
             (!ENABLE_SMOOTH_FALL ||
                 playerPhysics.isInRBounds(
                     playerPhysics.getAdjustedBottomR() +
-                    Math.ceil(interp.val / interpMax),
+                        Math.ceil(interp.val / interpMax),
                 )) &&
             areTargetSpacesEmpty(
                 Math.ceil(ENABLE_SMOOTH_FALL ? interp.val / interpMax : 0),
@@ -119,7 +119,7 @@ function updatePlayerPos(
             (!ENABLE_SMOOTH_FALL ||
                 playerPhysics.isInRBounds(
                     playerPhysics.getAdjustedBottomR() +
-                    Math.ceil(interp.val / interpMax),
+                        Math.ceil(interp.val / interpMax),
                 )) &&
             areTargetSpacesEmpty(
                 Math.ceil(ENABLE_SMOOTH_FALL ? interp.val / interpMax : 0),
@@ -245,7 +245,6 @@ const gameState = {
 };
 
 export function GameLoop() {
-
     const res = (
         <BoardStyled>
             <PlayerComponent
@@ -287,8 +286,8 @@ export function GameLoop() {
             if (
                 boardPhysics
                     .boardCellMatrix[playerPhysics.spawnPos[0]][
-                    playerPhysics.spawnPos[1]
-                ].char !== EMPTY
+                        playerPhysics.spawnPos[1]
+                    ].char !== EMPTY
             ) {
                 boardPhysics.resetBoard(BOARD_ROWS, BOARD_COLS);
             }

--- a/src/PlayerComponent.tsx
+++ b/src/PlayerComponent.tsx
@@ -6,6 +6,11 @@ export const PlayerComponent = React.memo(({ gameState, init }) => {
     // This function contains player information.
     const [playerCells, setPlayerCells] = useState(init); // Note: cells is not adjusted to the board.
     gameState.setPlayerCells = setPlayerCells;
+
+    const playerVisibility = React.useState(true); // Note: cells is not adjusted to the board.
+    gameState.setPlayerVisible = playerVisibility[1];
+    const isPlayerVisible = playerVisibility[0];
+
     const adjustedCellsStyled = playerCells.map((cell) => {
         const margin = ENABLE_SMOOTH_FALL ? interp.val : 0;
         const divStyle = {
@@ -18,7 +23,7 @@ export const PlayerComponent = React.memo(({ gameState, init }) => {
             marginTop: `${margin}%`,
             marginBottom: `${-margin}%`,
             justifyContent: "center",
-            visibility: gameState.isPlayerVisible ? 'visible' : 'hidden',
+            visibility: isPlayerVisible ? 'visible' : 'hidden',
             zIndex: 1,
         };
         return (

--- a/src/PlayerComponent.tsx
+++ b/src/PlayerComponent.tsx
@@ -18,6 +18,7 @@ export const PlayerComponent = React.memo(({ gameState, init }) => {
             marginTop: `${margin}%`,
             marginBottom: `${-margin}%`,
             justifyContent: "center",
+            visibility: gameState.isPlayerVisible ? 'visible' : 'hidden',
             zIndex: 1,
         };
         return (

--- a/src/PlayerComponent.tsx
+++ b/src/PlayerComponent.tsx
@@ -22,7 +22,9 @@ export const PlayerComponent = React.memo(({ gameState, init }) => {
             marginTop: `${margin}%`,
             marginBottom: `${-margin}%`,
             justifyContent: "center",
-            visibility: isPlayerVisible ? 'visible' : 'hidden',
+            visibility: isPlayerVisible
+                ? "visible" as const
+                : "hidden" as const,
             zIndex: 1,
         };
         return (

--- a/src/PlayerComponent.tsx
+++ b/src/PlayerComponent.tsx
@@ -7,9 +7,8 @@ export const PlayerComponent = React.memo(({ gameState, init }) => {
     const [playerCells, setPlayerCells] = useState(init); // Note: cells is not adjusted to the board.
     gameState.setPlayerCells = setPlayerCells;
 
-    const playerVisibility = React.useState(true); // Note: cells is not adjusted to the board.
-    gameState.setPlayerVisible = playerVisibility[1];
-    const isPlayerVisible = playerVisibility[0];
+    const [isPlayerVisible, setPlayerVisible] = React.useState(true); // Note: cells is not adjusted to the board.
+    gameState.setPlayerVisible = setPlayerVisible;
 
     const adjustedCellsStyled = playerCells.map((cell) => {
         const margin = ENABLE_SMOOTH_FALL ? interp.val : 0;


### PR DESCRIPTION
`rebase`d and `cherry-pick`ed version of #26 with a few fixes.

This PR makes the player block invisible and immovable while the word-match animation occurs.